### PR TITLE
Quick serve

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -5,56 +5,70 @@ PORT = "8000"
 
 # ---- BUILD & CREATE WASMS ----
 [tasks.compile]
-description = "Build"
+description = "Runs a standard, non-wasm debug compilation"
 workspace = false
 command = "cargo"
 args = ["build"]
 
 [tasks.compile_release]
-description = "Build, with the --release flag"
+description = "Runs a standard, non-wasm release compilation"
 workspace = false
 command = "cargo"
 args = ["build", "--release"]
 
-[tasks.create_wasm]
+[tasks.wasm]
 description = "Build with wasm-pack"
 install_crate = { crate_name = "wasm-pack", binary = "wasm-pack", test_arg = "-V", min_version = "0.8.0" }
 command = "wasm-pack"
 args = ["build", "--target", "web", "--out-name", "package", "--dev"]
 
-[tasks.create_wasm_release]
+[tasks.wasm_release]
 description = "Build with wasm-pack"
 install_crate = { crate_name = "wasm-pack", binary = "wasm-pack", test_arg = "-V", min_version = "0.8.0" }
 command = "wasm-pack"
 args = ["build", "--target", "web", "--out-name", "package"]
 
 [tasks.build]
-description = "Build, and create wasms"
+description = "Run both a regular, and wasm debug compilation"
 workspace = false
-dependencies = ["compile", "create_wasm"]
+dependencies = ["compile", "wasm"]
 
 [tasks.build_release]
-description = "Build, and create wasms, with the release flag"
+description = "Run both a regular, and wasm release compilation"
 workspace = false
-dependencies = ["compile_release", "create_wasm_release"]
+dependencies = ["compile_release", "wasm_release"]
 
 [tasks.watch]
-description = "Build, create wasms, and watch/recompile files for changes"
+description = "Build wasms, and watch/recompile files for changes"
 workspace = false
-dependencies = ["build", "create_wasm"]
+dependencies = ["build", "wasm"]
 watch = { ignore_pattern="pkg/*" }
 
-[tasks.serve]
-description = "Start server"
+[tasks.build_serve_release]
+description = "Start server with an up-to-date release build"
 install_crate = { crate_name = "microserver", binary = "microserver", test_arg = "-h" }
 workspace = false
+dependencies = ["wasm_realease"]
+command = "microserver"
+args = ["--port", "${PORT}"]
+
+[tasks.build_serve]
+description = "Start server with an up-to-date debug build"
+install_crate = { crate_name = "microserver", binary = "microserver", test_arg = "-h" }
+workspace = false
+dependencies = ["wasm"]
 command = "microserver"
 args = ["--port", "${PORT}"]
 
 [tasks.start]
 description = "Combine the build and serve tasks"
 workspace = false
-dependencies = ["build", "serve"]
+dependencies = ["build_serve"]
+
+[tasks.start_relese]
+description = "Combine the build and serve tasks"
+workspace = false
+dependencies = ["build_serve_release"]
 
 
 # ---- LINT ----

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -3,18 +3,23 @@
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = "true"
 PORT = "8000"
 
-# ---- BUILD & CREATE WASMS ----
+# ---- START THE SERVER. Intended as helper for other tasks ----
+
+[tasks.serve]
+description = "Invokes microserver. Run `cargo make wasm[_release]` first, or just `cargo make start[_release]` to run with a new build"
+install_crate = { crate_name = "microserver", binary = "microserver", test_arg = "-h" }
+workspace = false
+command = "microserver"
+args = ["--port", "${PORT}"]
+
+
+# ---- BUILD & CREATE WASMS IN DEBUG MODE ----
+
 [tasks.compile]
 description = "Runs a standard, non-wasm debug compilation"
 workspace = false
 command = "cargo"
 args = ["build"]
-
-[tasks.compile_release]
-description = "Runs a standard, non-wasm release compilation"
-workspace = false
-command = "cargo"
-args = ["build", "--release"]
 
 [tasks.wasm]
 description = "Build with wasm-pack"
@@ -22,53 +27,60 @@ install_crate = { crate_name = "wasm-pack", binary = "wasm-pack", test_arg = "-V
 command = "wasm-pack"
 args = ["build", "--target", "web", "--out-name", "package", "--dev"]
 
-[tasks.wasm_release]
-description = "Build with wasm-pack"
-install_crate = { crate_name = "wasm-pack", binary = "wasm-pack", test_arg = "-V", min_version = "0.8.0" }
-command = "wasm-pack"
-args = ["build", "--target", "web", "--out-name", "package"]
-
 [tasks.build]
 description = "Run both a regular, and wasm debug compilation"
 workspace = false
 dependencies = ["compile", "wasm"]
+
+
+# ---- BUILD & CREATE WASMS IN RELEASE MODE ----
+
+[tasks.compile_release]
+description = "Runs a standard, non-wasm release compilation"
+workspace = false
+command = "cargo"
+args = ["build", "--release"]
+
+[tasks.wasm_release]
+description = "Build with wasm-pack"
+install_crate = { crate_name = "wasm-pack", binary = "wasm-pack", test_arg = "-V", min_version = "0.8.0" }
+command = "wasm-pack"
+args = ["build", "--target", "web", "--out-name", "package", "--release"]
 
 [tasks.build_release]
 description = "Run both a regular, and wasm release compilation"
 workspace = false
 dependencies = ["compile_release", "wasm_release"]
 
+
+# ---- BUILD AND DEPLOY LOCALLY ----
+
+[tasks.start]
+description = "Combine the wasm-pack build and serve tasks"
+workspace = false
+dependencies = ["wasm", "serve"]
+
+[tasks.start_release]
+description = "Combine the wasm-pack build and serve tasks in release mode"
+workspace = false
+dependencies = ["wasm_release", "serve"]
+
+[tasks.build_serve]
+description = "Start server with an up-to-date debug build and wasm-build"
+install_crate = { crate_name = "microserver", binary = "microserver", test_arg = "-h" }
+workspace = false
+dependencies = ["build", "wasm", "serve"]
+
+[tasks.build_serve_release]
+description = "Start server with an up-to-date release build and wasm-build"
+workspace = false
+dependencies = ["build_release", "wasm_realease", "serve"]
+
 [tasks.watch]
 description = "Build wasms, and watch/recompile files for changes"
 workspace = false
-dependencies = ["build", "wasm"]
+dependencies = ["build"]
 watch = { ignore_pattern="pkg/*" }
-
-[tasks.build_serve_release]
-description = "Start server with an up-to-date release build"
-install_crate = { crate_name = "microserver", binary = "microserver", test_arg = "-h" }
-workspace = false
-dependencies = ["wasm_realease"]
-command = "microserver"
-args = ["--port", "${PORT}"]
-
-[tasks.build_serve]
-description = "Start server with an up-to-date debug build"
-install_crate = { crate_name = "microserver", binary = "microserver", test_arg = "-h" }
-workspace = false
-dependencies = ["wasm"]
-command = "microserver"
-args = ["--port", "${PORT}"]
-
-[tasks.start]
-description = "Combine the build and serve tasks"
-workspace = false
-dependencies = ["build_serve"]
-
-[tasks.start_relese]
-description = "Combine the build and serve tasks"
-workspace = false
-dependencies = ["build_serve_release"]
 
 
 # ---- LINT ----

--- a/README.md
+++ b/README.md
@@ -8,19 +8,18 @@
 
 `rustup update`
 
-`rustup target add wasm32-unknown-unknown`
-
 `cargo install cargo-make`
 
-Run `cargo make build` in a terminal to build the app, and `cargo make serve` to start a dev server
-on `127.0.0.1:8000`.
+Run `cargo make start` in a terminal to build the app, and start the server on `127.0.0.1:8000`.
+
+This will also install `cargo-wasm-pack` and add `wasm32-unknown-unknown` to your rustup toolchains
 
 If you'd like the compiler automatically check for changes, recompiling as
 needed, run `cargo make watch` instead of `cargo make build`.
 
 **Deploy**
 
-1. Run `cargo make build release`
+1. Run `cargo make start_release`
 2. Upload `index.html` and `pkg` to your web server
 
 ---


### PR DESCRIPTION
I made a silly mistake based on assumption and not reading the instructions on the website correctly. Thanks going out to rebo and fbucek for helping me in discord. This was a mistake that led to #12 

In short, I saw that `cargo make serve` was available, and assumed that it would handle the neccesary builds as well. If I read the website instructions correctly, I wouldn't have. That's `cargo make start`.

I've changed the Readme and tweaked the Makefile to hopefully reduce these occurrences. If this PR is accepted, I'll edit the website as well for consistency