### PR TITLE
Add preload links

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="preload" href="/pkg/package.js" as="script" type="text/javascript">
+    <link rel="preload" href="/pkg/package_bg.wasm" as="fetch" type="application/wasm">
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link rel="preload" href="/pkg/package.js" as="script" type="text/javascript">
-    <link rel="preload" href="/pkg/package_bg.wasm" as="fetch" type="application/wasm">
+    <link rel="modulepreload" href="/pkg/package.js" as="script" type="text/javascript">
+    <link rel="preload" href="/pkg/package_bg.wasm" as="fetch" type="application/wasm" crossorigin="anonymous">
 </head>
 
 <body>


### PR DESCRIPTION
Preload the javascript and wasm bundles. In my firefox network waterfall I can see this speeds up downloading as it can do it in parallel, then when the `fetch()` happens in the javascript file, the wasm bundle will be available already (or almost).

https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content